### PR TITLE
Update vault.md

### DIFF
--- a/universal/security/vault.md
+++ b/universal/security/vault.md
@@ -45,3 +45,4 @@ If you're doing heavy troubleshooting or have the need to disable Vault, the mai
 
 * Grab a new copy of OpenCore.efi
 * `Misc -> Security -> Vault` set to Optional
+* Remove `vault.plist` and `vault.sig`


### PR DESCRIPTION
Add another breaking factor to disabling Vault after setup.
- From my tests, if you simply replace OpenCore.efi and set "Vault" to "Optional," you will still corrupt the config.plist (you will not be able to boot).  I isolated this issue to this one factor.  However, I do have my own custom security, so at least having another reviewer confirm would be good idea.