### PR TITLE
ApECID command change

### DIFF
--- a/universal/security/applesecureboot.md
+++ b/universal/security/applesecureboot.md
@@ -136,7 +136,7 @@ However before setting ApECID, there's a few things we need to note:
 
 
 ```sh
- bless bless --folder "/Volumes/Macintosh HD/System/Library/CoreServices" \
+ bless bless --folder "/Volumes/Macintosh HD 1/System/Library/CoreServices" \
     --bootefi --personalize
 ```
 


### PR DESCRIPTION
In recovery, the recovery partition is named "Macintosh HD" and the system + data partition would be named "Macintosh HD 1"