### PR TITLE
Changed "PlayChime"'s setting to 'Enabled'

### DIFF
--- a/cosmetic/gui.md
+++ b/cosmetic/gui.md
@@ -105,7 +105,7 @@ So to start, we'll need a couple things:
   * Note boot-chime will not play if MinimumVolume is higher than `SystemAudioVolume` that we set back in the `NVRAM` section
 
 * **PlayChime:**
-  * Set this to `True`
+  * Set this to `Enabled`
 
 * **SetupDelay:**
   * By default, leave this at `0`


### PR DESCRIPTION
PlayChime needs to be one of 3: Enabled, Disabled, Auto, starting from 0.6.4. When set to True (String), boot chime will fail silently and it will be very hard to find out the culprit.