### PR TITLE
Updated gui.md

### DIFF
--- a/cosmetic/gui.md
+++ b/cosmetic/gui.md
@@ -25,7 +25,7 @@ Once you have both of these, we'll next want to add it to our EFI partition:
 Now in our config.plist, we have 4 things we need to fix:
 
 * `Misc -> Boot -> PickerMode`: `External`
-* `Misc -> Boot -> PickerAttributes`:`1`
+* `Misc -> Boot -> PickerAttributes`: `17`
   * This enables .VolumeIcon.icns reading off the drive, this is how macOS installer icons work
     * Other settings for PickerAttributes can be found in the [Configuration.pdf](https://github.com/acidanthera/OpenCorePkg/blob/master/Docs/Configuration.pdf)
 * `Misc -> Boot -> PickerVariant`: `Modern`

--- a/cosmetic/gui.md
+++ b/cosmetic/gui.md
@@ -26,7 +26,7 @@ Now in our config.plist, we have 4 things we need to fix:
 
 * `Misc -> Boot -> PickerMode`: `External`
 * `Misc -> Boot -> PickerAttributes`: `17`
-  * This enables .VolumeIcon.icns reading off the drive, this is how macOS installer icons work
+  * This enables mouse/trackpad support as well as .VolumeIcon.icns reading from the drive, allows for macOS installer icons to appear in the picker
     * Other settings for PickerAttributes can be found in the [Configuration.pdf](https://github.com/acidanthera/OpenCorePkg/blob/master/Docs/Configuration.pdf)
 * `Misc -> Boot -> PickerVariant`: `Modern`
   * Applicable variables:


### PR DESCRIPTION
Changed `PickerAttributes` from `1` to `17` as per OpenCore Configuration.pdf.
This means that the following options are enabled:

- `0x0001` --- `OC_ATTR_USE_VOLUME_ICON` which provides custom icons for boot entries
- `0x0010` --- `OC_ATTR_USE_POINTER_CONTROL` which enable pointer control in the picker when available. For example, this could make use of mouse or trackpad to control UI elements.