### PR TITLE
Add Bootstrap.efi as required file to be updated during OC update

### DIFF
--- a/universal/update.md
+++ b/universal/update.md
@@ -33,6 +33,7 @@ So the process goes as follows:
 * The important ones to update:
 
   * `EFI/BOOT/BOOTx64.efi`
+  * `EFI/OC/Bootstrap/Bootstrap.efi` (If you are using [Bootstrap](../multiboot/bootstrap.md) for multiboot.)
   * `EFI/OC/OpenCore.efi`
   * `EFI/OC/Drivers/OpenRuntime`(**Don't forget this one, OpenCore will not boot with mismatched versions**)
 


### PR DESCRIPTION
I updated OC for the first time and found that it is important to also update `Bootstrap.efi` when using multiboot. I only updated my `config.plist` and the three files currently listed in the docs. Since I have a Linux with systemd-boot installed, too, OC wouldn't boot anymore after that. This was probably due to mismatched versions of files and was fixed by also updating `Bootstrap.efi` which is quite obvious in hindsight. However, I am new to the hackintosh scene and to avoid that others have to find out on their own I propose to merge my addition to the docs.

Note: Please check if I set the link to the multiboot article correctly. I am not familiar with this documentation system.