### PR TITLE
[iServices] Fix BASH commands

### DIFF
--- a/universal/iservices.md
+++ b/universal/iservices.md
@@ -99,6 +99,7 @@ This is important for those who've tried setting up iMessage but failed, to star
 Next open terminal and run the following:
 
 ```
+bash
 sudo rm -rf ~/Library/Caches/com.apple.iCloudHelper*
 sudo rm -rf ~/Library/Caches/com.apple.Messages*
 sudo rm -rf ~/Library/Caches/com.apple.imfoundation.IMRemoteURLConnectionAgent*


### PR DESCRIPTION
Starting from macOS Mojave 10.15 (as far as I know) , zsh became the default shell for shells.
Executing the "Cleanup commands" that contains `*` like `sudo rm -rf ~/Library/Preferences/com.apple.madrid.plist*` may raise the following error:

`zsh: no matches found: /Users/${USER}/Library/Preferences/com.apple.ids.service*`

After using bash, the error is gone