### PR TITLE
Add Base and BaseSkip keys to GPRW-Patch.plist and UPRW-Patch.plist

### DIFF
--- a/extra-files/GPRW-Patch.plist
+++ b/extra-files/GPRW-Patch.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>#Don't forget the SSDT-GPRW</key>
+	<key>#Do not forget SSDT-GPRW</key>
 	<string>Without it this patch is worthless</string>
 	<key>ACPI</key>
 	<dict>

--- a/extra-files/GPRW-Patch.plist
+++ b/extra-files/GPRW-Patch.plist
@@ -2,13 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>#Don&apos;t forget the SSDT-GPRW</key>
+	<key>#Don't forget the SSDT-GPRW</key>
 	<string>Without it this patch is worthless</string>
 	<key>ACPI</key>
 	<dict>
 		<key>Patch</key>
 		<array>
 			<dict>
+				<key>Base</key>
+				<string></string>
+				<key>BaseSkip</key>
+				<integer>0</integer>
 				<key>Comment</key>
 				<string>change Method(GPRW,2,N) to XPRW, pair with SSDT-GPRW.aml</string>
 				<key>Count</key>

--- a/extra-files/UPRW-Patch.plist
+++ b/extra-files/UPRW-Patch.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>#Don't forget the SSDT-UPRW</key>
+	<key>#Do not forget SSDT-UPRW</key>
 	<string>Without it this patch is worthless</string>
 	<key>ACPI</key>
 	<dict>

--- a/extra-files/UPRW-Patch.plist
+++ b/extra-files/UPRW-Patch.plist
@@ -2,13 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>#Don&apos;t forget the SSDT-UPRW</key>
+	<key>#Don't forget the SSDT-UPRW</key>
 	<string>Without it this patch is worthless</string>
 	<key>ACPI</key>
 	<dict>
 		<key>Patch</key>
 		<array>
 			<dict>
+				<key>Base</key>
+				<string></string>
+				<key>BaseSkip</key>
+				<integer>0</integer>
 				<key>Comment</key>
 				<string>change Method(UPRW,2,N) to XPRW, pair with SSDT-UPRW.aml</string>
 				<key>Count</key>


### PR DESCRIPTION
Add Base and BaseSkip keys,Base and BaseSkip keys are required for OpenCore 0.6.8.