### PR TITLE
corrected picker attribute from '17' to '1'

### DIFF
--- a/cosmetic/gui.md
+++ b/cosmetic/gui.md
@@ -25,7 +25,7 @@ Once you have both of these, we'll next want to add it to our EFI partition:
 Now in our config.plist, we have 4 things we need to fix:
 
 * `Misc -> Boot -> PickerMode`: `External`
-* `Misc -> Boot -> PickerAttributes`: `17`
+* `Misc -> Boot -> PickerAttributes`: `1`
   * This enables mouse/trackpad support as well as .VolumeIcon.icns reading from the drive, allows for macOS installer icons to appear in the picker
     * Other settings for PickerAttributes can be found in the [Configuration.pdf](https://github.com/acidanthera/OpenCorePkg/blob/master/Docs/Configuration.pdf)
 * `Misc -> Boot -> PickerVariant`: `Acidanthera\GoldenGate`


### PR DESCRIPTION
On following the [guide](https://dortania.github.io/OpenCore-Post-Install/cosmetic/gui.html#setting-up-opencore-s-gui) using picker attribute '17' did nothing upon restarting and following the guide more than once. I noticed other sources were using value '1' so decided to create a PR for this