### PR TITLE
Change text selection color for code blocks.

### DIFF
--- a/.vuepress/styles/index.styl
+++ b/.vuepress/styles/index.styl
@@ -45,3 +45,8 @@ tr
   background-color var(--sideBgColor)!important
   box-shadow 0px 0px 2px var(--bodyBgColor)
   right -12%!important
+
+[data-theme="light"]
+  div[class*="language-"]
+    pre *::selection
+      background-color $textCodeSelectionColor

--- a/.vuepress/styles/palette.styl
+++ b/.vuepress/styles/palette.styl
@@ -14,6 +14,8 @@ $textColor = #2c3e50
 $bodyBgColor = #fff
 $sideBgColor = #fff
 $badgeTipColor = #caf2ff
+$textCodeSelectionColor = #2c3e50
+
 
 // Dark Theme
 $accentColorDark = #30BCD5


### PR DESCRIPTION
The text selection color in light mode makes almost impossible to know what text was highlighted. 

I changed the text selection color using the same color as the text in the document.