### PR TITLE
Vault.md: add how to UEFI Secure Boot and vault

### DIFF
--- a/universal/security/vault.md
+++ b/universal/security/vault.md
@@ -54,7 +54,7 @@ Notes:
 * These instructions can be read in the OpenCore configuration PDF (section 12.2 UEFFI Secure Boot), here they are explained in more detail.
 * For UEFI Secure Boot and macOS read this [post](https://github.com/dortania/OpenCore-Post-Install/blob/c0e7f282975f7d6224878b71648c27ce0ed304e6/universal/security/uefisecureboot.md).
 
-To have OpenCore vault and UEFI Secure Boot at the same time, it is required to follow an order when digitally signing drivers, tools and OpenCore.efi. If the user signs the files with the firmware keys and applies vault afterwards (or applies vault first and signs afterwards) OpenCore does not boot with a warning of OpenCore.efi corruption. It doesn't matter which of the 2 systems is applied first. 
+To have OpenCore vault and UEFI Secure Boot at the same time, it is required to follow an order when digitally signing drivers, tools and OpenCore.efi. If the user signs the files with the firmware keys and applies vault afterwards (or applies vault first and signs afterwards) OpenCore does not boot with a warning of OpenCore.efi corruption. It doesn't matter which of the 2 systems is applied first.
 
 The trick is in the order the files are signed with UEFI firmware personal keys and hashes created from vault.
 

--- a/universal/security/vault.md
+++ b/universal/security/vault.md
@@ -51,8 +51,8 @@ If you're doing heavy troubleshooting or have the need to disable Vault, the mai
 
 Notes:
 
-- These instructions can be read in the OpenCore configuration PDF (section 12.2 UEFFI Secure Boot), here they are explained in more detail.
-- For UEFI Secure Boot and macOS read this [post](https://github.com/dortania/OpenCore-Post-Install/blob/c0e7f282975f7d6224878b71648c27ce0ed304e6/universal/security/uefisecureboot.md).
+* These instructions can be read in the OpenCore configuration PDF (section 12.2 UEFFI Secure Boot), here they are explained in more detail.
+* For UEFI Secure Boot and macOS read this [post](https://github.com/dortania/OpenCore-Post-Install/blob/c0e7f282975f7d6224878b71648c27ce0ed304e6/universal/security/uefisecureboot.md).
 
 To have OpenCore vault and UEFI Secure Boot at the same time, it is necessary to follow an order when digitally signing drivers, tools and OpenCore.efi. If the user signs the files with the keys shoved in the firmware and then applies vault, the computer does not boot. It doesn't matter which of the 2 systems is applied first, after doing digital signature and vault (or in reverse order) OpenCore doesn't boot with a warning of OpenCore.efi corruption.
 
@@ -63,9 +63,9 @@ This requires moving from macOS to Windows and viceversa a few times. In order n
 The steps are:
 
 1. On Ubuntu >> Sign all the installed drivers and tools with the private key. Do not sign tools that provide administrative access to the computer, such as UEFI Shell. Do not sign OpenCore.efi.
-3. On macOS >> Add the signed files into the EFI folder and vault it.
-4. On Ubuntu >> Sign the OpenCore.efi file which already has Vault applied.
-5. Back in macOS >> Copy the EFI folder into the EFI partition.
-6. Reboot >> Enable UEFI Secure Boot.
+2. On macOS >> Add the signed files into the EFI folder and vault it.
+3. On Ubuntu >> Sign the OpenCore.efi file which already has Vault applied.
+4. Back in macOS >> Copy the EFI folder into the EFI partition.
+5. Reboot >> Enable UEFI Secure Boot.
 
 If everything has gone well, we see the OpenCore picker screen and we can boot macOS with vault and UEFI Secure Boot both applied.

--- a/universal/security/vault.md
+++ b/universal/security/vault.md
@@ -46,3 +46,26 @@ If you're doing heavy troubleshooting or have the need to disable Vault, the mai
 * Grab a new copy of OpenCore.efi
 * `Misc -> Security -> Vault` set to Optional
 * Remove `vault.plist` and `vault.sig`
+
+**OpenCore Vault + UEFI Secure Boot**
+
+Notes:
+
+- These instructions can be read in the OpenCore configuration PDF (section 12.2 UEFFI Secure Boot), here they are explained in more detail.
+- For UEFI Secure Boot and macOS read this [post](https://github.com/dortania/OpenCore-Post-Install/blob/c0e7f282975f7d6224878b71648c27ce0ed304e6/universal/security/uefisecureboot.md).
+
+To have OpenCore vault and UEFI Secure Boot at the same time, it is necessary to follow an order when digitally signing drivers, tools and OpenCore.efi. If the user signs the files with the keys shoved in the firmware and then applies vault, the computer does not boot. It doesn't matter which of the 2 systems is applied first, after doing digital signature and vault (or in reverse order) OpenCore doesn't boot with a warning of OpenCore.efi corruption.
+
+The key is in the order the files are signed, both with UEFI firmware personal keys and hashes created from vault.
+
+This requires moving from macOS to Windows and viceversa a few times. In order not to have to switch from macOS to Windows so many times, you can install an Ubuntu virtual machine on macOS or build an Ubuntu boot USB memory stick.
+
+The steps are:
+
+1. On Ubuntu >> Sign all the installed drivers and tools with the private key. Do not sign tools that provide administrative access to the computer, such as UEFI Shell. Do not sign OpenCore.efi.
+3. On macOS >> Add the signed files into the EFI folder and vault it.
+4. On Ubuntu >> Sign the OpenCore.efi file which already has Vault applied.
+5. Back in macOS >> Copy the EFI folder into the EFI partition.
+6. Reboot >> Enable UEFI Secure Boot.
+
+If everything has gone well, we see the OpenCore picker screen and we can boot macOS with vault and UEFI Secure Boot both applied.

--- a/universal/security/vault.md
+++ b/universal/security/vault.md
@@ -54,9 +54,9 @@ Notes:
 * These instructions can be read in the OpenCore configuration PDF (section 12.2 UEFFI Secure Boot), here they are explained in more detail.
 * For UEFI Secure Boot and macOS read this [post](https://github.com/dortania/OpenCore-Post-Install/blob/c0e7f282975f7d6224878b71648c27ce0ed304e6/universal/security/uefisecureboot.md).
 
-To have OpenCore vault and UEFI Secure Boot at the same time, it is necessary to follow an order when digitally signing drivers, tools and OpenCore.efi. If the user signs the files with the keys shoved in the firmware and then applies vault, the computer does not boot. It doesn't matter which of the 2 systems is applied first, after doing digital signature and vault (or in reverse order) OpenCore doesn't boot with a warning of OpenCore.efi corruption.
+To have OpenCore vault and UEFI Secure Boot at the same time, it is required to follow an order when digitally signing drivers, tools and OpenCore.efi. If the user signs the files with the firmware keys and applies vault afterwards (or applies vault first and signs afterwards) OpenCore does not boot with a warning of OpenCore.efi corruption. It doesn't matter which of the 2 systems is applied first. 
 
-The key is in the order the files are signed, both with UEFI firmware personal keys and hashes created from vault.
+The trick is in the order the files are signed with UEFI firmware personal keys and hashes created from vault.
 
 This requires moving from macOS to Windows and viceversa a few times. In order not to have to switch from macOS to Windows so many times, you can install an Ubuntu virtual machine on macOS or build an Ubuntu boot USB memory stick.
 


### PR DESCRIPTION
These instructions can be read in the OpenCore configuration PDF (section 12.2 UEFFI Secure Boot) but, in my opinion, they should also be in the OpenCore Post-Install Guide.