### PR TITLE
This fix is intended to correct the GPRW to XPRW patch because it con…

### DIFF
--- a/extra-files/GPRW-Patch.plist
+++ b/extra-files/GPRW-Patch.plist
@@ -20,7 +20,7 @@
 				<key>Enabled</key>
 				<true/>
 				<key>Find</key>
-				<data>R1BSVwI=</data>
+				<data>R1BSVw==</data>
 				<key>Limit</key>
 				<integer>0</integer>
 				<key>Mask</key>
@@ -28,7 +28,7 @@
 				<key>OemTableId</key>
 				<data></data>
 				<key>Replace</key>
-				<data>WFBSVwI=</data>
+				<data>WFBSVw==</data>
 				<key>ReplaceMask</key>
 				<data></data>
 				<key>Skip</key>


### PR DESCRIPTION
This fix is intended to correct the GPRW to XPRW patch because it contains a certain error in which it presents invalid characters at the end, thus making the purpose of the patch inaccessible. In the original, at the end of each code (47505257 and 58505257, respectively, there is a number 02). Without these characters now, it becomes possible to make the correction correctly.