### PR TITLE
Update iservices.md wireshark manuf url

### DIFF
--- a/universal/iservices.md
+++ b/universal/iservices.md
@@ -75,7 +75,7 @@ Select a MAC Address with an Organizationally Unique Identifier (OUI) that corre
 
 See the following list:
 
-[https://gitlab.com/wireshark/wireshark/-/raw/master/manuf](https://gitlab.com/wireshark/wireshark/-/raw/master/manuf)
+[https://www.wireshark.org/download/automated/data/manuf](https://www.wireshark.org/download/automated/data/manuf)
 
 For example:
 


### PR DESCRIPTION
Update wireshark manuf url

The manuf file has been removed in master as of commit 131b1e42, which replaces it with built-in static arrays in order to speed up Wireshark's start time