### PR TITLE
Fix 404 to 6.4 version of ACPI specs 

### DIFF
--- a/usb/amd-mapping/amd.md
+++ b/usb/amd-mapping/amd.md
@@ -7,7 +7,7 @@ Table of Contents:
 * [Port mapping on screwed up DSDTs](#port-mapping-on-screwed-up-dsdts)
 * [Port mapping when you have multiple of the same controller](#port-mapping-when-you-have-multiple-of-the-same-controller)
 
-So with the prerequisites out of the way, we can finally get to the meat of this guide. And now we get to finally read one of my favorite books before I go to bed each night: [The Advanced Configuration and Power Interface (ACPI) Specification!](https://uefi.org/specs/ACPI/6.4/)
+So with the prerequisites out of the way, we can finally get to the meat of this guide. And now we get to finally read one of my favorite books before I go to bed each night: [The Advanced Configuration and Power Interface (ACPI) Specification!](https://uefi.org/specs/ACPI/6.5/)
 
 Now if you haven't read through this before(which I highly recommend you do, it's a thrilling tale), I'll point you to the meat of the USB situation:
 

--- a/usb/intel-mapping/intel.md
+++ b/usb/intel-mapping/intel.md
@@ -6,7 +6,7 @@ Table of Contents:
 
 * [Intel USB Mapping](#Intel-usb-mapping)
 
-So with the prerequisites out of the way, we can finally get to the meat of this guide. And now we get to finally read one of my favorite books before I go to bed each night: [The Advanced Configuration and Power Interface (ACPI) Specification!](https://uefi.org/specs/ACPI/6.4/)
+So with the prerequisites out of the way, we can finally get to the meat of this guide. And now we get to finally read one of my favorite books before I go to bed each night: [The Advanced Configuration and Power Interface (ACPI) Specification!](https://uefi.org/specs/ACPI/6.5/)
 
 Now if you haven't read through this before(which I highly recommend you do, it's a thrilling tale), I'll point you to the meat of the USB situation:
 

--- a/usb/manual/manual.md
+++ b/usb/manual/manual.md
@@ -1,6 +1,6 @@
 # USB Mapping
 
-So with the prerequisites out of the way, we can finally get to the meat of this guide. And now we get to finally read one of my favorite books before I go to bed each night: [The Advanced Configuration and Power Interface (ACPI) Specification!](https://uefi.org/specs/ACPI/6.4/)
+So with the prerequisites out of the way, we can finally get to the meat of this guide. And now we get to finally read one of my favorite books before I go to bed each night: [The Advanced Configuration and Power Interface (ACPI) Specification!](https://uefi.org/specs/ACPI/6.5/)
 
 Now if you haven't read through this before(which I highly recommend you do, it's a thrilling tale), I'll point you to the meat of the USB situation:
 


### PR DESCRIPTION
Just replaced the link with the new version, https://uefi.org/specs/ACPI/6.5/