### PR TITLE
Update BusID patching page to include more concise information regarding specific port types. 

### DIFF
--- a/gpu-patching/intel-patching/busid.md
+++ b/gpu-patching/intel-patching/busid.md
@@ -59,7 +59,8 @@ Things to keep in mind:
 * BusID is a unique value and cannot be used by multiple entries
 * Connector-type values are the same as discussed in the [Connector-type patching page](./connector.md)
 * Only certain BusID's are permitted based on the connector type
-  ** test
+ * For DisplayPort `0x02`,`0x04`,`0x05` and `0x06` are allowed and should work on any motherboard. These values apply to VGA as well
+ * For HDMI `0x01`,`0x02`,`0x04` and `0x06` are allowed, however some motherboards may only accept one or two of these values. These value apply to DVI as well
 
 ## Mapping the video ports
 

--- a/gpu-patching/intel-patching/busid.md
+++ b/gpu-patching/intel-patching/busid.md
@@ -58,6 +58,8 @@ Things to keep in mind:
 
 * BusID is a unique value and cannot be used by multiple entries
 * Connector-type values are the same as discussed in the [Connector-type patching page](./connector.md)
+* Only certain BusID's are permitted based on the connector type
+  ** test
 
 ## Mapping the video ports
 
@@ -232,3 +234,5 @@ When done, you should get something similar:
 ![](../../images/gpu-patching/path-done.png)
 
 And as mentioned before, if this combo doesn't work, increment port 1's BusID and if that doesn't work disable port 1's busID and try port 2 and so forth.
+
+

--- a/gpu-patching/intel-patching/busid.md
+++ b/gpu-patching/intel-patching/busid.md
@@ -59,8 +59,8 @@ Things to keep in mind:
 * BusID is a unique value and cannot be used by multiple entries
 * Connector-type values are the same as discussed in the [Connector-type patching page](./connector.md)
 * Only certain BusID's are permitted based on the connector type
- * For DisplayPort `0x02`,`0x04`,`0x05` and `0x06` are allowed and should work on any motherboard. These values apply to VGA as well
- * For HDMI `0x01`,`0x02`,`0x04` and `0x06` are allowed, however some motherboards may only accept one or two of these values. These value apply to DVI as well
+  * For DisplayPort `0x02`,`0x04`,`0x05` and `0x06` are allowed and should work on any motherboard. These values apply to VGA as well
+  * For HDMI `0x01`,`0x02`,`0x04` and `0x06` are allowed, however some motherboards may only accept one or two of these values. These value apply to DVI as well
 
 ## Mapping the video ports
 


### PR DESCRIPTION
I've found this information useful when trying to troubleshoot a display output problem on my machine since the whatevergreen configuration used BusID only meant for DisplayPort and changing it to one meant for HDMI fixed the issue. 

Maybe a more proeminently featured section at the start talking about cycling BusID's to fix the display problem and how to do it would be better as I initially ignored the mapping without MacOS section given that I had 1 display working withing MacOS. Or updating the Mapping withing MacOS section to remove the kaby lake example and update it to include information on using something like ioregistry explorer to identify the currently working connection and then cycling the BusID's on the other connections until the issues is fixed. 