### PR TITLE
Revise MAC Address OUI source links

### DIFF
--- a/universal/iservices.md
+++ b/universal/iservices.md
@@ -74,8 +74,8 @@ The value on the right is your **Board Serial (MLB)**.
 Select a MAC Address with an Organizationally Unique Identifier (OUI) that corresponds to a real Apple, Inc. interface.
 
 See the following list:
-
-[https://gitlab.com/wireshark/wireshark/-/raw/master/manuf](https://gitlab.com/wireshark/wireshark/-/raw/master/manuf)
+Original Source - [https://gitlab.com/wireshark/wireshark/-/raw/master/manuf](https://gitlab.com/wireshark/wireshark/-/raw/master/manuf)
+Mirror - [https://www.wireshark.org/download/automated/data/manuf](https://www.wireshark.org/download/automated/data/manuf)
 
 For example:
 


### PR DESCRIPTION
LINK TO WIRESHARK ISSUE: https://github.com/sickcodes/Docker-OSX/issues/681#issuecomment-1859826469

This pull request updates the documentation in `universal/iservices.md` to improve clarity and provide an additional resource for users selecting a MAC Address OUI. The most important change is the addition of a mirror link for the manufacturer list, making it easier for users to access the necessary information.

Documentation improvements:

* Added a "Mirror" link to the Wireshark manufacturer list alongside the original source, ensuring users have an alternative resource if the original is unavailable.